### PR TITLE
fix: refresh conversations on incoming SMS

### DIFF
--- a/src/hooks/message-thread.ts
+++ b/src/hooks/message-thread.ts
@@ -3,13 +3,13 @@ import toast from '@/components/toaster'
 import { initLazyQuery, smsGQL } from '@/lib/api/query'
 import { useI18n } from 'vue-i18n'
 import { buildQuery } from '@/lib/search'
-import type { IItemTagsUpdatedEvent, IItemsTagsUpdatedEvent, IMessage, INotification } from '@/lib/interfaces'
+import type { IItemTagsUpdatedEvent, IItemsTagsUpdatedEvent, IMessage } from '@/lib/interfaces'
 import { useTags } from '@/hooks/tags'
 import { useContactName } from '@/hooks/contacts'
 import { DataType } from '@/lib/data'
 import emitter from '@/plugins/eventbus'
 import { createPendingSms, createPendingMms } from '@/lib/message-helpers'
-import { shouldTriggerRefresh } from '@/lib/sms-whitelist'
+import { createSmsNotificationRefresh } from '@/hooks/sms-notification-refresh'
 
 const PAGE_SIZE = 100
 
@@ -120,21 +120,19 @@ export function useMessageThread(threadId: Ref<string>, chatScrollRef: Ref<HTMLE
 
   const onItemsTagsUpdated = (e: IItemsTagsUpdatedEvent) => { if (e.type === DataType.SMS) fetch() }
   const onItemTagsUpdated = (e: IItemTagsUpdatedEvent) => { if (e.type === DataType.SMS) fetch() }
-  const onNotificationCreated = (data: INotification) => { if (shouldTriggerRefresh(data)) fetch() }
+  const notificationRefresh = createSmsNotificationRefresh(fetch)
 
   function subscribe() {
     fetchTags(); loadContacts()
     emitter.on('item_tags_updated', onItemTagsUpdated)
     emitter.on('items_tags_updated', onItemsTagsUpdated)
-    emitter.on('notification_created', onNotificationCreated)
-    emitter.on('notification_updated', onNotificationCreated)
+    notificationRefresh.subscribe()
   }
 
   function unsubscribe() {
     emitter.off('item_tags_updated', onItemTagsUpdated)
     emitter.off('items_tags_updated', onItemsTagsUpdated)
-    emitter.off('notification_created', onNotificationCreated)
-    emitter.off('notification_updated', onNotificationCreated)
+    notificationRefresh.unsubscribe()
   }
 
   return {

--- a/src/hooks/messages-sidebar.ts
+++ b/src/hooks/messages-sidebar.ts
@@ -17,6 +17,7 @@ import { useSelectable } from '@/hooks/list'
 import type { IData } from '@/lib/interfaces'
 import type { Ref } from 'vue'
 import emitter from '@/plugins/eventbus'
+import { createSmsNotificationRefresh } from '@/hooks/sms-notification-refresh'
 
 export const sortItems = [
   { label: 'sort_by.date_desc', value: 'DATE_DESC' },
@@ -108,6 +109,7 @@ export function useMessagesSidebar() {
   }
 
   const smsSentHandler = () => { setTimeout(() => applyRouteQuery(), 1500) }
+  const notificationRefresh = createSmsNotificationRefresh(applyRouteQuery)
 
   watch(() => route.query.q, () => { if (isActive.value && !isArchived.value) applyRouteQuery() })
 
@@ -116,11 +118,13 @@ export function useMessagesSidebar() {
     loadContacts()
     applyRouteQuery()
     emitter.on('sms_sent' as any, smsSentHandler)
+    notificationRefresh.subscribe()
   })
 
   onDeactivated(() => {
     isActive.value = false
     emitter.off('sms_sent' as any, smsSentHandler)
+    notificationRefresh.unsubscribe()
   })
 
   return {

--- a/src/hooks/sms-notification-refresh.ts
+++ b/src/hooks/sms-notification-refresh.ts
@@ -1,0 +1,32 @@
+import type { INotification } from '@/lib/interfaces'
+import emitter from '@/plugins/eventbus'
+import { shouldTriggerRefresh } from '@/lib/sms-whitelist'
+
+export const SMS_NOTIFICATION_REFRESH_DELAY_MS = 500
+
+export function createSmsNotificationRefresh(refresh: () => void) {
+  let timeout: ReturnType<typeof setTimeout> | undefined
+
+  function handleNotification(notification: INotification) {
+    if (!shouldTriggerRefresh(notification)) return
+    if (timeout) clearTimeout(timeout)
+    timeout = setTimeout(() => {
+      timeout = undefined
+      refresh()
+    }, SMS_NOTIFICATION_REFRESH_DELAY_MS)
+  }
+
+  function subscribe() {
+    emitter.on('notification_created', handleNotification)
+    emitter.on('notification_updated', handleNotification)
+  }
+
+  function unsubscribe() {
+    emitter.off('notification_created', handleNotification)
+    emitter.off('notification_updated', handleNotification)
+    if (timeout) clearTimeout(timeout)
+    timeout = undefined
+  }
+
+  return { subscribe, unsubscribe }
+}

--- a/tests/lib/sms-notification-refresh.test.ts
+++ b/tests/lib/sms-notification-refresh.test.ts
@@ -1,0 +1,105 @@
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import emitter from '@/plugins/eventbus'
+import type { INotification } from '@/lib/interfaces'
+import {
+  createSmsNotificationRefresh,
+  SMS_NOTIFICATION_REFRESH_DELAY_MS,
+} from '@/hooks/sms-notification-refresh'
+
+function notification(appId: string): INotification {
+  return { appId } as INotification
+}
+
+const cleanups: Array<() => void> = []
+
+afterEach(() => {
+  cleanups.splice(0).forEach((cleanup) => cleanup())
+  vi.useRealTimers()
+})
+
+function subscribe(refresh: () => void) {
+  const subscription = createSmsNotificationRefresh(refresh)
+  subscription.subscribe()
+  cleanups.push(subscription.unsubscribe)
+  return subscription
+}
+
+describe('SMS notification refresh', () => {
+  it('refreshes after a recognized SMS notification settles', () => {
+    vi.useFakeTimers()
+    const refresh = vi.fn()
+    subscribe(refresh)
+
+    emitter.emit('notification_created', notification('com.google.android.apps.messaging'))
+
+    expect(refresh).not.toHaveBeenCalled()
+    vi.advanceTimersByTime(SMS_NOTIFICATION_REFRESH_DELAY_MS)
+    expect(refresh).toHaveBeenCalledTimes(1)
+  })
+
+  it('coalesces notification create and update events into one refresh', () => {
+    vi.useFakeTimers()
+    const refresh = vi.fn()
+    subscribe(refresh)
+
+    emitter.emit('notification_created', notification('com.android.mms'))
+    vi.advanceTimersByTime(SMS_NOTIFICATION_REFRESH_DELAY_MS - 1)
+    emitter.emit('notification_updated', notification('com.android.mms'))
+    vi.advanceTimersByTime(SMS_NOTIFICATION_REFRESH_DELAY_MS - 1)
+
+    expect(refresh).not.toHaveBeenCalled()
+    vi.advanceTimersByTime(1)
+    expect(refresh).toHaveBeenCalledTimes(1)
+  })
+
+  it('ignores notifications from unrelated apps', () => {
+    vi.useFakeTimers()
+    const refresh = vi.fn()
+    subscribe(refresh)
+
+    emitter.emit('notification_created', notification('com.example.calendar'))
+    vi.advanceTimersByTime(SMS_NOTIFICATION_REFRESH_DELAY_MS)
+
+    expect(refresh).not.toHaveBeenCalled()
+  })
+
+  it('cancels pending refreshes and listeners when unsubscribed', () => {
+    vi.useFakeTimers()
+    const refresh = vi.fn()
+    const subscription = subscribe(refresh)
+
+    emitter.emit('notification_created', notification('com.android.mms'))
+    subscription.unsubscribe()
+    emitter.emit('notification_updated', notification('com.android.mms'))
+    vi.advanceTimersByTime(SMS_NOTIFICATION_REFRESH_DELAY_MS)
+
+    expect(refresh).not.toHaveBeenCalled()
+  })
+
+  it('resumes refreshing after a view is reactivated', () => {
+    vi.useFakeTimers()
+    const refresh = vi.fn()
+    const subscription = subscribe(refresh)
+
+    subscription.unsubscribe()
+    subscription.subscribe()
+    emitter.emit('notification_created', notification('com.android.mms'))
+    vi.advanceTimersByTime(SMS_NOTIFICATION_REFRESH_DELAY_MS)
+
+    expect(refresh).toHaveBeenCalledTimes(1)
+  })
+
+  it('refreshes independent active consumers', () => {
+    vi.useFakeTimers()
+    const refreshThread = vi.fn()
+    const refreshSidebar = vi.fn()
+    subscribe(refreshThread)
+    subscribe(refreshSidebar)
+
+    emitter.emit('notification_updated', notification('com.android.mms'))
+    vi.advanceTimersByTime(SMS_NOTIFICATION_REFRESH_DELAY_MS)
+
+    expect(refreshThread).toHaveBeenCalledTimes(1)
+    expect(refreshSidebar).toHaveBeenCalledTimes(1)
+  })
+})


### PR DESCRIPTION
## Summary

- refresh the conversation sidebar when supported SMS apps emit incoming notification events
- share and debounce notification refresh handling between the active thread and sidebar
- cancel pending refreshes on view deactivation and cover filtering, coalescing, cleanup, reactivation, and independent subscribers

## Verification

- `corepack yarn vitest run tests/lib/sms-notification-refresh.test.ts --project unit` — 6 passed
- `corepack yarn typecheck` — passed
- `corepack yarn eslint src/hooks/message-thread.ts src/hooks/messages-sidebar.ts src/hooks/sms-notification-refresh.ts tests/lib/sms-notification-refresh.test.ts` — passed
- `corepack yarn build` — passed
- `RUSTUP_TOOLCHAIN=1.96.0 corepack yarn build:tauri` — passed; generated DEB, RPM, and AppImage bundles
- `corepack yarn test` — 426 passed, 52 skipped, and the same 3 pre-existing web-mode/local-mode assertions failed in `local-mode.test.ts` and `window-client.test.ts`

A paired Android device with an active SMS subscription was not available for carrier-to-device validation. The focused tests exercise the notification event path used by the phone WebSocket client.

Fixes #14
